### PR TITLE
fix requirements.txt

### DIFF
--- a/REQUIREMENTS.txt
+++ b/REQUIREMENTS.txt
@@ -1,3 +1,3 @@
-django = 1.9
-django_auth_ldap = 1.2.7
-ldap
+django==1.9
+django_auth_ldap==1.2.7
+pyldap==2.4.25


### PR DESCRIPTION
This PR fixes a minor issue when installing this repo:

``` bash
pip install -r REQUIREMENTS.txt 
Invalid requirement: 'django = 1.9'
= is not a valid operator. Did you mean == ?
```

I've also renamed `ldap` to `pyldap`.
